### PR TITLE
add the master version of Typesense image ^0.24.0.rcn17. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,9 @@ services:
       - yb-master
 
   typesense:
-    build: ./dockerfiles/typesense
+    image: typesense/typesense:0.24.0.rcn17
+    container_name: typesense-0-24-0-rcn17
+    # build: ./dockerfiles/typesense
     command: --data-dir=/data --api-key=searchkey
     ports:
       - "8108:8108"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,9 +52,7 @@ services:
       - yb-master
 
   typesense:
-    image: typesense/typesense:0.24.0.rcn17
-    container_name: typesense-0-24-0-rcn17
-    # build: ./dockerfiles/typesense
+    build: ./dockerfiles/typesense
     command: --data-dir=/data --api-key=searchkey
     ports:
       - "8108:8108"

--- a/dockerfiles/typesense/Dockerfile
+++ b/dockerfiles/typesense/Dockerfile
@@ -1,4 +1,4 @@
-FROM typesense/typesense:0.23.1
+FROM typesense/typesense:0.24.0.rcn21
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
why is this one is happening? because the current stable version doesn't support the nested field. it'll be supported at least on the 0.24 version